### PR TITLE
Added a method to set your language

### DIFF
--- a/components/account.js
+++ b/components/account.js
@@ -220,3 +220,26 @@ SteamStore.prototype.hasPhone = function(callback) {
 		callback(new Error("Malformed response"));
 	});
 };
+
+SteamStore.prototype.setDisplayLanguages = function(prim_language, sec_languages, callback) {
+	if(typeof(sec_languages) == "function") {
+		callback = sec_languages;
+		sec_languages = undefined;
+	}
+	
+	var self = this;
+	this.request.post({
+		"uri": "https://store.steampowered.com/account/savelanguagepreferences",
+		"form": {
+			"sessionid": this.getSessionID(),
+			"primary_language": prim_language,
+			"secondary_languages": sec_languages || [],
+		}
+	}, function(err, response, body) {
+		if(self._checkHttpError(err, response, callback)) {
+			return;
+		}
+
+		callback(null);
+	});
+};


### PR DESCRIPTION
setDisplayLanguages(prim_language, [sec_languages], callback)
- prim_language: a string (Ex: "english", "portuguese")
- sec_languages: an array of strings (Ex: ["russian", "french"])

This should change the language of everything. Added this because the language on steam-trade-offer-manager and steam-community wasn't being correctly set, making trade offer errors and inventory descriptions to be shown in other languages. Using this method at the start shuold fix all that.

Taken from view-source:https://store.steampowered.com/account/languagepreferences/ @line 427