### PR TITLE
Updated "redeemable" return value of createWallet()

### DIFF
--- a/components/account.js
+++ b/components/account.js
@@ -280,7 +280,7 @@ SteamStore.prototype.createWallet = function(code, billingAddress, callback) {
 			return;
 		}
 
-		callback(null, body.success, body.detail, body.success == EResult.OK && body.detail == EPurchaseResult.NoDetail, body.wallet && body.wallet.amount, body.wallet && body.wallet.currencycode);
+		callback(null, body.success, body.detail, body.success == EResult.OK && body.detail && body.detail == EPurchaseResult.NoDetail, body.wallet && body.wallet.amount, body.wallet && body.wallet.currencycode);
 	});
 };
 


### PR DESCRIPTION
Without it, it returns redeemable: false even if the code is redeemable when purchasedetail is undefined